### PR TITLE
Use GitHub cache instead of FTP to use OpenDDS artifacts within pull request and Release workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,7 +145,7 @@ jobs:
       - name: Save OpenDDS in cache
         uses: actions/cache/save@v3
         with:
-          path: $GITHUB_WORKSPACE/OutputOpenDDS/
+          path: ./OutputOpenDDS/
           key: OpenDDS_3.25
 
       - name: Upload OpenDDS
@@ -275,7 +275,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           fail-on-cache-miss: true
-          path: $GITHUB_WORKSPACE/OutputOpenDDS/
+          path: ./OutputOpenDDS/
           key: OpenDDS_3.25
 
     #  - name: Download OpenDDS Binaries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,7 @@ jobs:
         id: cache
         with:
           lookup-only: true
+          path: ~\OpenDDS_Build_3.25.zip
           key: OpenDDS_Build_3.25
           
      # - name: Exists OpenDDS

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -143,19 +143,19 @@ jobs:
       - name: Save OpenDDS Binaries in cache
         uses: actions/cache/save@v3
         with:
-          path: %GITHUB_WORKSPACE%\OpenDDS_Build_3.25.zip
+          path: ~\OpenDDS_Build_3.25.zip
           key: OpenDDS_Build_3.25
           
       - name: Save OpenDDS PDB in cache
         uses: actions/cache/save@v3
         with:
-          path: %GITHUB_WORKSPACE%\OpenDDS_PDB_Build_3.25.zip
+          path: ~\OpenDDS_PDB_Build_3.25.zip
           key: OpenDDS_PDB_Build_3.25
           
       - name: Save OpenDDS Headers in cache
         uses: actions/cache/save@v3
         with:
-          path: %GITHUB_WORKSPACE%\OpenDDS_Headers_3.25.zip
+          path: ~\OpenDDS_Headers_3.25.zip
           key: OpenDDS_Headers_3.25
 
     #  - name: Upload OpenDDS
@@ -282,13 +282,13 @@ jobs:
       - name: Restore OpenDDS Binaries from cache
         uses: actions/cache/restore@v3
         with:
-          path: %GITHUB_WORKSPACE%\OpenDDS_Build_3.25.zip
+          path: ~\OpenDDS_Build_3.25.zip
           key: OpenDDS_Build_3.25
 
       - name: Restore OpenDDS Headers from cache
         uses: actions/cache/restore@v3
         with:
-          path: %GITHUB_WORKSPACE%\OpenDDS_Headers_3.25.zip
+          path: ~\OpenDDS_Headers_3.25.zip
           key: OpenDDS_Headers_3.25
 
     #  - name: Download OpenDDS Binaries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
         id: cache
         with:
           lookup-only: true
-          path: ~\third_party\OpenDDS\
+          path: ./OutputOpenDDS/
           key: OpenDDS_3.25
           
      # - name: Exists OpenDDS

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,7 +145,7 @@ jobs:
       - name: Save OpenDDS in cache
         uses: actions/cache/save@v3
         with:
-          path: ~/OutputOpenDDS/
+          path: $GITHUB_WORKSPACE/OutputOpenDDS/
           key: OpenDDS_3.25
 
       - name: Upload OpenDDS
@@ -275,7 +275,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           fail-on-cache-miss: true
-          path: ~/OutputOpenDDS/
+          path: $GITHUB_WORKSPACE/OutputOpenDDS/
           key: OpenDDS_3.25
 
     #  - name: Download OpenDDS Binaries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,15 +20,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          submodules: 'true'
+      #  with:
+      #    submodules: 'true'
 
       - uses: actions/cache@v3
         id: cache
         with:
           lookup-only: true
-          path: ~\OpenDDS_Build_3.25.zip
-          key: OpenDDS_Build_3.25
+          path: ~\third_party\OpenDDS\
+          key: OpenDDS_3.25
           
      # - name: Exists OpenDDS
      #   id: existsOpenDDS
@@ -141,32 +141,21 @@ jobs:
           7z a .\OpenDDS_Headers_3.25.zip .\third_party\OpenDDS\*.h -r
           7z u .\OpenDDS_Headers_3.25.zip .\third_party\OpenDDS\*.inl -r
 
-      - name: Save OpenDDS Binaries in cache
+      - name: Save OpenDDS in cache
         uses: actions/cache/save@v3
         with:
-          path: ~\OpenDDS_Build_3.25.zip
-          key: OpenDDS_Build_3.25
-          
-      - name: Save OpenDDS PDB in cache
-        uses: actions/cache/save@v3
-        with:
-          path: ~\OpenDDS_PDB_Build_3.25.zip
-          key: OpenDDS_PDB_Build_3.25
-          
-      - name: Save OpenDDS Headers in cache
-        uses: actions/cache/save@v3
-        with:
-          path: ~\OpenDDS_Headers_3.25.zip
-          key: OpenDDS_Headers_3.25
+          path: ~\third_party\OpenDDS\
+          key: OpenDDS_3.25
 
-    #  - name: Upload OpenDDS
-    #    shell: cmd
-    #    run: |
-    #      python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Build_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Build_3.25.zip
-    #      python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_PDB_Build_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_PDB_Build_3.25.zip
-    #      python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Headers_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Headers_3.25.zip
-    #    env:
-    #      GITHUB_WORKSPACE: $GITHUB_WORKSPACE
+      - name: Upload OpenDDS
+        if: ${{ github.repository_owner == 'masesgroup'}} # do not upload any artifact outside main repo
+        shell: cmd
+        run: |
+          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Build_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Build_3.25.zip
+          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_PDB_Build_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_PDB_Build_3.25.zip
+          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Headers_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Headers_3.25.zip
+        env:
+          GITHUB_WORKSPACE: $GITHUB_WORKSPACE
 
   # Verify if a build is needed
   check_changes:
@@ -274,23 +263,18 @@ jobs:
           echo ${{ env.NUGET_PACKAGE_VERSION }}
         shell: cmd
 
-      - name: Configure OpenDDS to download ACE/TAO
-        shell: cmd
-        run: |
-          cd third_party\OpenDDS
-          configure
+    #  - name: Configure OpenDDS to download ACE/TAO
+    #    shell: cmd
+    #    run: |
+    #      cd third_party\OpenDDS
+    #      configure
 
-      - name: Restore OpenDDS Binaries from cache
+      - name: Restore OpenDDS from cache
         uses: actions/cache/restore@v3
         with:
-          path: ~\OpenDDS_Build_3.25.zip
-          key: OpenDDS_Build_3.25
-
-      - name: Restore OpenDDS Headers from cache
-        uses: actions/cache/restore@v3
-        with:
-          path: ~\OpenDDS_Headers_3.25.zip
-          key: OpenDDS_Headers_3.25
+          fail-on-cache-miss: true
+          path: ~\third_party\OpenDDS\
+          key: OpenDDS_3.25
 
     #  - name: Download OpenDDS Binaries
     #    shell: cmd
@@ -306,13 +290,13 @@ jobs:
     #    env:
     #      GITHUB_WORKSPACE: $GITHUB_WORKSPACE
 
-      - name: Prepare OpenDDS Binaries
-        run: |
-          Expand-Archive -LiteralPath '.\OpenDDS_Build_3.25.zip' -DestinationPath .\Output -Force
-          
-      - name: Prepare OpenDDS Headers
-        run: |
-          Expand-Archive -LiteralPath '.\OpenDDS_Headers_3.25.zip' -DestinationPath .\third_party\OpenDDS -Force
+    #  - name: Prepare OpenDDS Binaries
+    #    run: |
+    #      Expand-Archive -LiteralPath '.\OpenDDS_Build_3.25.zip' -DestinationPath .\Output -Force
+    #      
+    #  - name: Prepare OpenDDS Headers
+    #    run: |
+    #      Expand-Archive -LiteralPath '.\OpenDDS_Headers_3.25.zip' -DestinationPath .\third_party\OpenDDS -Force
 
       - name: Move OpenDDS x64
         shell: cmd

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -132,28 +132,30 @@ jobs:
 
       - name: Prepare for packaging OpenDDS Binaries and PDB
         run: |
-          Compress-Archive -Path .\Output\* -DestinationPath .\OpenDDS_Build_3.25.zip
-          Compress-Archive -Path .\OutputPdb\* -DestinationPath .\OpenDDS_PDB_Build_3.25.zip
+          New-Item -Path .\OutputOpenDDS -ItemType directory
+          Compress-Archive -Path .\Output\* -DestinationPath .\OutputOpenDDS\OpenDDS_Build_3.25.zip
+          Compress-Archive -Path .\OutputPdb\* -DestinationPath .\OutputOpenDDS\OpenDDS_PDB_Build_3.25.zip
 
       - name: Prepare for packaging OpenDDS Headers
         shell: cmd
         run: |
-          7z a .\OpenDDS_Headers_3.25.zip .\third_party\OpenDDS\*.h -r
-          7z u .\OpenDDS_Headers_3.25.zip .\third_party\OpenDDS\*.inl -r
+          7z a .\OutputOpenDDS\OpenDDS_Headers_3.25.zip .\third_party\OpenDDS\*.h -r
+          7z u .\OutputOpenDDS\OpenDDS_Headers_3.25.zip .\third_party\OpenDDS\*.inl -r
 
       - name: Save OpenDDS in cache
         uses: actions/cache/save@v3
         with:
-          path: ~\third_party\OpenDDS\
+          path: ~/OutputOpenDDS/
           key: OpenDDS_3.25
 
       - name: Upload OpenDDS
         if: ${{ github.repository_owner == 'masesgroup'}} # do not upload any artifact outside main repo
+        continue-on-error: true
         shell: cmd
         run: |
-          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Build_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Build_3.25.zip
-          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_PDB_Build_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_PDB_Build_3.25.zip
-          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Headers_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Headers_3.25.zip
+          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Build_3.25.zip -l %GITHUB_WORKSPACE%\OutputOpenDDS\OpenDDS_Build_3.25.zip
+          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_PDB_Build_3.25.zip -l %GITHUB_WORKSPACE%\OutputOpenDDS\OpenDDS_PDB_Build_3.25.zip
+          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Headers_3.25.zip -l %GITHUB_WORKSPACE%\OutputOpenDDS\OpenDDS_Headers_3.25.zip
         env:
           GITHUB_WORKSPACE: $GITHUB_WORKSPACE
 
@@ -263,17 +265,17 @@ jobs:
           echo ${{ env.NUGET_PACKAGE_VERSION }}
         shell: cmd
 
-    #  - name: Configure OpenDDS to download ACE/TAO
-    #    shell: cmd
-    #    run: |
-    #      cd third_party\OpenDDS
-    #      configure
+      - name: Configure OpenDDS to download ACE/TAO
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          configure
 
       - name: Restore OpenDDS from cache
         uses: actions/cache/restore@v3
         with:
           fail-on-cache-miss: true
-          path: ~\third_party\OpenDDS\
+          path: ~/OutputOpenDDS/
           key: OpenDDS_3.25
 
     #  - name: Download OpenDDS Binaries
@@ -290,13 +292,13 @@ jobs:
     #    env:
     #      GITHUB_WORKSPACE: $GITHUB_WORKSPACE
 
-    #  - name: Prepare OpenDDS Binaries
-    #    run: |
-    #      Expand-Archive -LiteralPath '.\OpenDDS_Build_3.25.zip' -DestinationPath .\Output -Force
-    #      
-    #  - name: Prepare OpenDDS Headers
-    #    run: |
-    #      Expand-Archive -LiteralPath '.\OpenDDS_Headers_3.25.zip' -DestinationPath .\third_party\OpenDDS -Force
+      - name: Prepare OpenDDS Binaries
+        run: |
+          Expand-Archive -LiteralPath '.\OutputOpenDDS\OpenDDS_Build_3.25.zip' -DestinationPath .\Output -Force
+          
+      - name: Prepare OpenDDS Headers
+        run: |
+          Expand-Archive -LiteralPath '.\OutputOpenDDS\OpenDDS_Headers_3.25.zip' -DestinationPath .\third_party\OpenDDS -Force
 
       - name: Move OpenDDS x64
         shell: cmd

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ on:
   push:
     # only trigger on branches, not on tags
     branches: '**'
-   
+
 # This workflow contains two jobs called "check_opendds", "build_opendds_windows", "check_changes", "build_ddm_windows"
 jobs:
   # Verify if a build is needed

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
       #  with:
       #    submodules: 'true'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         id: cache
         with:
           lookup-only: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,16 +22,23 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'true'
-    
-      - name: Exists OpenDDS
-        id: existsOpenDDS
-        continue-on-error: true
-        run: |
-          python $GITHUB_WORKSPACE/third_party/CommonTools/scripts/utilsftp.py -c check -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Build_3.25.zip -l $GITHUB_WORKSPACE/OpenDDS_Build_3.25.zip
+
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          lookup-only: true
+          key: OpenDDS_Build_3.25
+          
+     # - name: Exists OpenDDS
+     #   id: existsOpenDDS
+     #   continue-on-error: true
+     #   run: |
+     #     python $GITHUB_WORKSPACE/third_party/CommonTools/scripts/utilsftp.py -c check -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Build_3.25.zip -l $GITHUB_WORKSPACE/OpenDDS_Build_3.25.zip
 
       - name: If failed we need to rebuild artifact
         id: check_existsOpenDDS
-        if: ${{ steps.existsOpenDDS.outcome == 'failure' }}
+        if: steps.cache.outputs.cache-hit != 'true'
+       # if: ${{ steps.existsOpenDDS.outcome == 'failure' }}
         run: echo "build_opendds=true" >> $GITHUB_OUTPUT
 
   build_opendds_windows:
@@ -133,14 +140,32 @@ jobs:
           7z a .\OpenDDS_Headers_3.25.zip .\third_party\OpenDDS\*.h -r
           7z u .\OpenDDS_Headers_3.25.zip .\third_party\OpenDDS\*.inl -r
 
-      - name: Upload OpenDDS
-        shell: cmd
-        run: |
-          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Build_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Build_3.25.zip
-          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_PDB_Build_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_PDB_Build_3.25.zip
-          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Headers_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Headers_3.25.zip
-        env:
-          GITHUB_WORKSPACE: $GITHUB_WORKSPACE
+      - name: Save OpenDDS Binaries in cache
+        uses: actions/cache/save@v3
+        with:
+          path: %GITHUB_WORKSPACE%\OpenDDS_Build_3.25.zip
+          key: OpenDDS_Build_3.25
+          
+      - name: Save OpenDDS PDB in cache
+        uses: actions/cache/save@v3
+        with:
+          path: %GITHUB_WORKSPACE%\OpenDDS_PDB_Build_3.25.zip
+          key: OpenDDS_PDB_Build_3.25
+          
+      - name: Save OpenDDS Headers in cache
+        uses: actions/cache/save@v3
+        with:
+          path: %GITHUB_WORKSPACE%\OpenDDS_Headers_3.25.zip
+          key: OpenDDS_Headers_3.25
+
+    #  - name: Upload OpenDDS
+    #    shell: cmd
+    #    run: |
+    #      python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Build_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Build_3.25.zip
+    #      python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_PDB_Build_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_PDB_Build_3.25.zip
+    #      python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c upload -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Headers_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Headers_3.25.zip
+    #    env:
+    #      GITHUB_WORKSPACE: $GITHUB_WORKSPACE
 
   # Verify if a build is needed
   check_changes:
@@ -193,7 +218,7 @@ jobs:
           submodules: 'true'
 
       - name: Cache local Maven repository
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -254,19 +279,31 @@ jobs:
           cd third_party\OpenDDS
           configure
 
-      - name: Download OpenDDS Binaries
-        shell: cmd
-        run: |
-          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c download -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Build_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Build_3.25.zip
-        env:
-          GITHUB_WORKSPACE: $GITHUB_WORKSPACE
-          
-      - name: Download OpenDDS Headers
-        shell: cmd
-        run: |
-          python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c download -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Headers_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Headers_3.25.zip
-        env:
-          GITHUB_WORKSPACE: $GITHUB_WORKSPACE
+      - name: Restore OpenDDS Binaries from cache
+        uses: actions/cache/restore@v3
+        with:
+          path: %GITHUB_WORKSPACE%\OpenDDS_Build_3.25.zip
+          key: OpenDDS_Build_3.25
+
+      - name: Restore OpenDDS Headers from cache
+        uses: actions/cache/restore@v3
+        with:
+          path: %GITHUB_WORKSPACE%\OpenDDS_Headers_3.25.zip
+          key: OpenDDS_Headers_3.25
+
+    #  - name: Download OpenDDS Binaries
+    #    shell: cmd
+    #    run: |
+    #      python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c download -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Build_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Build_3.25.zip
+    #    env:
+    #      GITHUB_WORKSPACE: $GITHUB_WORKSPACE
+    #      
+    #  - name: Download OpenDDS Headers
+    #    shell: cmd
+    #    run: |
+    #      python %GITHUB_WORKSPACE%\third_party\CommonTools\scripts\utilsftp.py -c download -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Headers_3.25.zip -l %GITHUB_WORKSPACE%\OpenDDS_Headers_3.25.zip
+    #    env:
+    #      GITHUB_WORKSPACE: $GITHUB_WORKSPACE
 
       - name: Prepare OpenDDS Binaries
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ on:
   push:
     # only trigger on branches, not on tags
     branches: '**'
-    
+   
 # This workflow contains two jobs called "check_opendds", "build_opendds_windows", "check_changes", "build_ddm_windows"
 jobs:
   # Verify if a build is needed

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,7 @@ jobs:
         id: cache
         with:
           lookup-only: true
+          enableCrossOsArchive: true
           path: ./OutputOpenDDS/
           key: OpenDDS_3.25
           
@@ -145,6 +146,7 @@ jobs:
       - name: Save OpenDDS in cache
         uses: actions/cache/save@v3
         with:
+          enableCrossOsArchive: true
           path: ./OutputOpenDDS/
           key: OpenDDS_3.25
 
@@ -275,6 +277,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           fail-on-cache-miss: true
+          enableCrossOsArchive: true
           path: ./OutputOpenDDS/
           key: OpenDDS_3.25
 

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -9,6 +9,143 @@ on:
     branches: [ master ]
 
 jobs:
+  # Verify if a build is needed
+  check_opendds:
+    name: Check artifact files
+    outputs:
+      build_opendds: ${{ steps.check_existsOpenDDS.outputs.build_opendds }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      #  with:
+      #    submodules: 'true'
+
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          lookup-only: true
+          path: ./OutputOpenDDS/
+          key: OpenDDS_3.25
+          
+     # - name: Exists OpenDDS
+     #   id: existsOpenDDS
+     #   continue-on-error: true
+     #   run: |
+     #     python $GITHUB_WORKSPACE/third_party/CommonTools/scripts/utilsftp.py -c check -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Build_3.25.zip -l $GITHUB_WORKSPACE/OpenDDS_Build_3.25.zip
+
+      - name: If failed we need to rebuild artifact
+        id: check_existsOpenDDS
+        if: steps.cache.outputs.cache-hit != 'true'
+       # if: ${{ steps.existsOpenDDS.outcome == 'failure' }}
+        run: echo "build_opendds=true" >> $GITHUB_OUTPUT
+
+  build_opendds_windows:
+    needs: check_opendds
+    if: needs.check_opendds.outputs.build_opendds == 'true'
+    # The type of runner that the job will run on
+    runs-on: windows-2022
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Runs a set of commands using the runners shell
+      # Support longpaths
+      - name: Support long paths
+        run: git config --system core.longpaths true
+      
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+          
+      - name: set up msvc env
+        uses: ilammy/msvc-dev-cmd@v1.12.1
+
+      - name: Configure OpenDDS
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          configure
+
+      - name: Build OpenDDS x64
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          call setenv.cmd
+          msbuild -p:Configuration=Release,Platform=x64 -m DDS_TAOv2.sln
+
+      - name: Move OpenDDS x64 binaries
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          xcopy .\lib\*.dll ..\..\Output\x64\
+          xcopy .\lib\*.lib ..\..\Output\lib64\
+          xcopy .\bin\*.exe ..\..\Output\bin64\
+          xcopy .\ACE_wrappers\lib\*.dll ..\..\Output\x64\
+          xcopy .\ACE_wrappers\lib\*.lib ..\..\Output\lib64\
+          xcopy .\ACE_wrappers\bin\*.exe ..\..\Output\bin64\
+          
+      - name: Move OpenDDS x64 PDB
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          mkdir ..\..\OutputPdb
+          xcopy .\lib\*.pdb ..\..\OutputPdb\pdb64\
+          xcopy .\bin\*.pdb ..\..\OutputPdb\pdb64\
+          xcopy .\ACE_wrappers\lib\*.pdb ..\..\OutputPdb\pdb64\
+          xcopy .\ACE_wrappers\bin\*.pdb ..\..\OutputPdb\pdb64\
+
+      - name: Build OpenDDS x86
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          call setenv.cmd
+          msbuild -p:Configuration=Release,Platform=Win32 -m DDS_TAOv2.sln
+
+      - name: Move OpenDDS x86 binaries
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          xcopy .\lib\*.dll ..\..\Output\x86\
+          xcopy .\lib\*.lib ..\..\Output\lib32\
+          xcopy .\bin\*.exe ..\..\Output\bin32\
+          xcopy .\ACE_wrappers\lib\*.dll ..\..\Output\x86\
+          xcopy .\ACE_wrappers\lib\*.lib ..\..\Output\lib32\
+          xcopy .\ACE_wrappers\bin\*.exe ..\..\Output\bin32\
+
+      - name: Move OpenDDS x86 PDB
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          xcopy .\lib\*.pdb ..\..\OutputPdb\pdb32\
+          xcopy .\bin\*.pdb ..\..\OutputPdb\pdb32\
+          xcopy .\ACE_wrappers\lib\*.pdb ..\..\OutputPdb\pdb32\
+          xcopy .\ACE_wrappers\bin\*.pdb ..\..\OutputPdb\pdb32\
+
+      - name: Move setenv.cmd
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          xcopy setenv.cmd ..\..\Output\
+
+      - name: Prepare for packaging OpenDDS Binaries and PDB
+        run: |
+          New-Item -Path .\OutputOpenDDS -ItemType directory
+          Compress-Archive -Path .\Output\* -DestinationPath .\OutputOpenDDS\OpenDDS_Build_3.25.zip
+          Compress-Archive -Path .\OutputPdb\* -DestinationPath .\OutputOpenDDS\OpenDDS_PDB_Build_3.25.zip
+
+      - name: Prepare for packaging OpenDDS Headers
+        shell: cmd
+        run: |
+          7z a .\OutputOpenDDS\OpenDDS_Headers_3.25.zip .\third_party\OpenDDS\*.h -r
+          7z u .\OutputOpenDDS\OpenDDS_Headers_3.25.zip .\third_party\OpenDDS\*.inl -r
+
+      - name: Save OpenDDS in cache
+        uses: actions/cache/save@v3
+        with:
+          path: ./OutputOpenDDS/
+          key: OpenDDS_3.25
+
   # This workflow contains a single job called "build_release"
   build_pullrequest:
     # The type of runner that the job will run on
@@ -69,49 +206,72 @@ jobs:
           cd third_party\OpenDDS
           configure
 
-      - name: Build OpenDDS x64
-        shell: cmd
+      - name: Restore OpenDDS from cache
+        uses: actions/cache/restore@v3
+        with:
+          fail-on-cache-miss: true
+          path: ./OutputOpenDDS/
+          key: OpenDDS_3.25
+
+      - name: Prepare OpenDDS Binaries
         run: |
-          cd third_party\OpenDDS
-          call setenv.cmd
-          msbuild -p:Configuration=Release,Platform=x64 -m DDS_TAOv2.sln
+          Expand-Archive -LiteralPath '.\OutputOpenDDS\OpenDDS_Build_3.25.zip' -DestinationPath .\Output -Force
+          
+      - name: Prepare OpenDDS Headers
+        run: |
+          Expand-Archive -LiteralPath '.\OutputOpenDDS\OpenDDS_Headers_3.25.zip' -DestinationPath .\third_party\OpenDDS -Force
 
       - name: Move OpenDDS x64
         shell: cmd
         run: |
-          cd third_party\OpenDDS
-          xcopy .\lib\*.dll ..\..\Output\x64\
-          xcopy .\lib\*.pdb ..\..\Output\pdb64\
-          xcopy .\lib\*.lib ..\..\Output\lib64\
-          xcopy .\bin\*.exe ..\..\Output\bin64\
-          xcopy .\bin\*.pdb ..\..\Output\pdb64\
-          xcopy .\ACE_wrappers\lib\*.dll ..\..\Output\x64\
-          xcopy .\ACE_wrappers\lib\*.pdb ..\..\Output\pdb64\
-          xcopy .\ACE_wrappers\lib\*.lib ..\..\Output\lib64\
-          xcopy .\ACE_wrappers\bin\*.exe ..\..\Output\bin64\
-          xcopy .\ACE_wrappers\bin\*.pdb ..\..\Output\pdb64\
+           xcopy .\Output\bin32\*.* .\third_party\OpenDDS\bin\
+           xcopy .\Output\x86\*.dll .\third_party\OpenDDS\lib\
+           xcopy .\Output\bin32\*.* .\third_party\OpenDDS\ACE_wrappers\bin\
+           xcopy .\Output\x86\*.dll .\third_party\OpenDDS\ACE_wrappers\lib\
 
-      - name: Build OpenDDS x86
-        shell: cmd
-        run: |
-          cd third_party\OpenDDS
-          call setenv.cmd
-          msbuild -p:Configuration=Release,Platform=Win32 -m DDS_TAOv2.sln
-
-      - name: Move OpenDDS x86
-        shell: cmd
-        run: |
-          cd third_party\OpenDDS
-          xcopy .\lib\*.dll ..\..\Output\x86\
-          xcopy .\lib\*.pdb ..\..\Output\pdb32\
-          xcopy .\lib\*.lib ..\..\Output\lib32\
-          xcopy .\bin\*.exe ..\..\Output\bin32\
-          xcopy .\bin\*.pdb ..\..\Output\pdb32\
-          xcopy .\ACE_wrappers\lib\*.dll ..\..\Output\x86\
-          xcopy .\ACE_wrappers\lib\*.pdb ..\..\Output\pdb32\
-          xcopy .\ACE_wrappers\lib\*.lib ..\..\Output\lib32\
-          xcopy .\ACE_wrappers\bin\*.exe ..\..\Output\bin32\
-          xcopy .\ACE_wrappers\bin\*.pdb ..\..\Output\pdb32\
+    #  - name: Build OpenDDS x64
+    #    shell: cmd
+    #    run: |
+    #      cd third_party\OpenDDS
+    #      call setenv.cmd
+    #      msbuild -p:Configuration=Release,Platform=x64 -m DDS_TAOv2.sln
+    #
+    #  - name: Move OpenDDS x64
+    #    shell: cmd
+    #    run: |
+    #      cd third_party\OpenDDS
+    #      xcopy .\lib\*.dll ..\..\Output\x64\
+    #      xcopy .\lib\*.pdb ..\..\Output\pdb64\
+    #      xcopy .\lib\*.lib ..\..\Output\lib64\
+    #      xcopy .\bin\*.exe ..\..\Output\bin64\
+    #      xcopy .\bin\*.pdb ..\..\Output\pdb64\
+    #      xcopy .\ACE_wrappers\lib\*.dll ..\..\Output\x64\
+    #      xcopy .\ACE_wrappers\lib\*.pdb ..\..\Output\pdb64\
+    #      xcopy .\ACE_wrappers\lib\*.lib ..\..\Output\lib64\
+    #      xcopy .\ACE_wrappers\bin\*.exe ..\..\Output\bin64\
+    #      xcopy .\ACE_wrappers\bin\*.pdb ..\..\Output\pdb64\
+    #
+    #  - name: Build OpenDDS x86
+    #    shell: cmd
+    #    run: |
+    #      cd third_party\OpenDDS
+    #      call setenv.cmd
+    #      msbuild -p:Configuration=Release,Platform=Win32 -m DDS_TAOv2.sln
+    #
+    #  - name: Move OpenDDS x86
+    #    shell: cmd
+    #    run: |
+    #      cd third_party\OpenDDS
+    #      xcopy .\lib\*.dll ..\..\Output\x86\
+    #      xcopy .\lib\*.pdb ..\..\Output\pdb32\
+    #      xcopy .\lib\*.lib ..\..\Output\lib32\
+    #      xcopy .\bin\*.exe ..\..\Output\bin32\
+    #      xcopy .\bin\*.pdb ..\..\Output\pdb32\
+    #      xcopy .\ACE_wrappers\lib\*.dll ..\..\Output\x86\
+    #      xcopy .\ACE_wrappers\lib\*.pdb ..\..\Output\pdb32\
+    #      xcopy .\ACE_wrappers\lib\*.lib ..\..\Output\lib32\
+    #      xcopy .\ACE_wrappers\bin\*.exe ..\..\Output\bin32\
+    #      xcopy .\ACE_wrappers\bin\*.pdb ..\..\Output\pdb32\
 
       - name: Generate OpenDDS projects
         shell: cmd

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -148,6 +148,8 @@ jobs:
 
   # This workflow contains a single job called "build_release"
   build_pullrequest:
+    needs: [check_opendds, build_opendds_windows]
+    if: always()
     # The type of runner that the job will run on
     runs-on: windows-2022
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -21,7 +21,7 @@ jobs:
       #  with:
       #    submodules: 'true'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         id: cache
         with:
           lookup-only: true

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -25,6 +25,7 @@ jobs:
         id: cache
         with:
           lookup-only: true
+          enableCrossOsArchive: true
           path: ./OutputOpenDDS/
           key: OpenDDS_3.25
           
@@ -143,6 +144,7 @@ jobs:
       - name: Save OpenDDS in cache
         uses: actions/cache/save@v3
         with:
+          enableCrossOsArchive: true
           path: ./OutputOpenDDS/
           key: OpenDDS_3.25
 
@@ -212,6 +214,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           fail-on-cache-miss: true
+          enableCrossOsArchive: true
           path: ./OutputOpenDDS/
           key: OpenDDS_3.25
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       #  with:
       #    submodules: 'true'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         id: cache
         with:
           lookup-only: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,6 +150,8 @@ jobs:
 
   # This workflow contains a single job called "build_release"
   build_release:
+    needs: [check_opendds, build_opendds_windows]
+    if: always()
     # The type of runner that the job will run on
     runs-on: windows-2022
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,143 @@ on:
       - edited
 
 jobs:
+  # Verify if a build is needed
+  check_opendds:
+    name: Check artifact files
+    outputs:
+      build_opendds: ${{ steps.check_existsOpenDDS.outputs.build_opendds }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      #  with:
+      #    submodules: 'true'
+
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          lookup-only: true
+          path: ./OutputOpenDDS/
+          key: OpenDDS_3.25
+          
+     # - name: Exists OpenDDS
+     #   id: existsOpenDDS
+     #   continue-on-error: true
+     #   run: |
+     #     python $GITHUB_WORKSPACE/third_party/CommonTools/scripts/utilsftp.py -c check -s ${{ secrets.FTP_STORE_SITE }} -u ${{ secrets.FTP_STORE_USER }} -p ${{ secrets.FTP_STORE_PASSWORD }} -r OpenDDS_Build_3.25.zip -l $GITHUB_WORKSPACE/OpenDDS_Build_3.25.zip
+
+      - name: If failed we need to rebuild artifact
+        id: check_existsOpenDDS
+        if: steps.cache.outputs.cache-hit != 'true'
+       # if: ${{ steps.existsOpenDDS.outcome == 'failure' }}
+        run: echo "build_opendds=true" >> $GITHUB_OUTPUT
+        
+  build_opendds_windows:
+    needs: check_opendds
+    if: needs.check_opendds.outputs.build_opendds == 'true'
+    # The type of runner that the job will run on
+    runs-on: windows-2022
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Runs a set of commands using the runners shell
+      # Support longpaths
+      - name: Support long paths
+        run: git config --system core.longpaths true
+      
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+          
+      - name: set up msvc env
+        uses: ilammy/msvc-dev-cmd@v1.12.1
+
+      - name: Configure OpenDDS
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          configure
+
+      - name: Build OpenDDS x64
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          call setenv.cmd
+          msbuild -p:Configuration=Release,Platform=x64 -m DDS_TAOv2.sln
+
+      - name: Move OpenDDS x64 binaries
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          xcopy .\lib\*.dll ..\..\Output\x64\
+          xcopy .\lib\*.lib ..\..\Output\lib64\
+          xcopy .\bin\*.exe ..\..\Output\bin64\
+          xcopy .\ACE_wrappers\lib\*.dll ..\..\Output\x64\
+          xcopy .\ACE_wrappers\lib\*.lib ..\..\Output\lib64\
+          xcopy .\ACE_wrappers\bin\*.exe ..\..\Output\bin64\
+          
+      - name: Move OpenDDS x64 PDB
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          mkdir ..\..\OutputPdb
+          xcopy .\lib\*.pdb ..\..\OutputPdb\pdb64\
+          xcopy .\bin\*.pdb ..\..\OutputPdb\pdb64\
+          xcopy .\ACE_wrappers\lib\*.pdb ..\..\OutputPdb\pdb64\
+          xcopy .\ACE_wrappers\bin\*.pdb ..\..\OutputPdb\pdb64\
+
+      - name: Build OpenDDS x86
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          call setenv.cmd
+          msbuild -p:Configuration=Release,Platform=Win32 -m DDS_TAOv2.sln
+
+      - name: Move OpenDDS x86 binaries
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          xcopy .\lib\*.dll ..\..\Output\x86\
+          xcopy .\lib\*.lib ..\..\Output\lib32\
+          xcopy .\bin\*.exe ..\..\Output\bin32\
+          xcopy .\ACE_wrappers\lib\*.dll ..\..\Output\x86\
+          xcopy .\ACE_wrappers\lib\*.lib ..\..\Output\lib32\
+          xcopy .\ACE_wrappers\bin\*.exe ..\..\Output\bin32\
+
+      - name: Move OpenDDS x86 PDB
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          xcopy .\lib\*.pdb ..\..\OutputPdb\pdb32\
+          xcopy .\bin\*.pdb ..\..\OutputPdb\pdb32\
+          xcopy .\ACE_wrappers\lib\*.pdb ..\..\OutputPdb\pdb32\
+          xcopy .\ACE_wrappers\bin\*.pdb ..\..\OutputPdb\pdb32\
+
+      - name: Move setenv.cmd
+        shell: cmd
+        run: |
+          cd third_party\OpenDDS
+          xcopy setenv.cmd ..\..\Output\
+
+      - name: Prepare for packaging OpenDDS Binaries and PDB
+        run: |
+          New-Item -Path .\OutputOpenDDS -ItemType directory
+          Compress-Archive -Path .\Output\* -DestinationPath .\OutputOpenDDS\OpenDDS_Build_3.25.zip
+          Compress-Archive -Path .\OutputPdb\* -DestinationPath .\OutputOpenDDS\OpenDDS_PDB_Build_3.25.zip
+
+      - name: Prepare for packaging OpenDDS Headers
+        shell: cmd
+        run: |
+          7z a .\OutputOpenDDS\OpenDDS_Headers_3.25.zip .\third_party\OpenDDS\*.h -r
+          7z u .\OutputOpenDDS\OpenDDS_Headers_3.25.zip .\third_party\OpenDDS\*.inl -r
+
+      - name: Save OpenDDS in cache
+        uses: actions/cache/save@v3
+        with:
+          path: ./OutputOpenDDS/
+          key: OpenDDS_3.25
+
   # This workflow contains a single job called "build_release"
   build_release:
     # The type of runner that the job will run on
@@ -86,49 +223,72 @@ jobs:
           cd third_party\OpenDDS
           configure
 
-      - name: Build OpenDDS x64
-        shell: cmd
+      - name: Restore OpenDDS from cache
+        uses: actions/cache/restore@v3
+        with:
+          fail-on-cache-miss: true
+          path: ./OutputOpenDDS/
+          key: OpenDDS_3.25
+
+      - name: Prepare OpenDDS Binaries
         run: |
-          cd third_party\OpenDDS
-          call setenv.cmd
-          msbuild -p:Configuration=Release,Platform=x64 -m DDS_TAOv2.sln
+          Expand-Archive -LiteralPath '.\OutputOpenDDS\OpenDDS_Build_3.25.zip' -DestinationPath .\Output -Force
+          
+      - name: Prepare OpenDDS Headers
+        run: |
+          Expand-Archive -LiteralPath '.\OutputOpenDDS\OpenDDS_Headers_3.25.zip' -DestinationPath .\third_party\OpenDDS -Force
 
       - name: Move OpenDDS x64
         shell: cmd
         run: |
-          cd third_party\OpenDDS
-          xcopy .\lib\*.dll ..\..\Output\x64\
-          xcopy .\lib\*.pdb ..\..\Output\pdb64\
-          xcopy .\lib\*.lib ..\..\Output\lib64\
-          xcopy .\bin\*.exe ..\..\Output\bin64\
-          xcopy .\bin\*.pdb ..\..\Output\pdb64\
-          xcopy .\ACE_wrappers\lib\*.dll ..\..\Output\x64\
-          xcopy .\ACE_wrappers\lib\*.pdb ..\..\Output\pdb64\
-          xcopy .\ACE_wrappers\lib\*.lib ..\..\Output\lib64\
-          xcopy .\ACE_wrappers\bin\*.exe ..\..\Output\bin64\
-          xcopy .\ACE_wrappers\bin\*.pdb ..\..\Output\pdb64\
+           xcopy .\Output\bin32\*.* .\third_party\OpenDDS\bin\
+           xcopy .\Output\x86\*.dll .\third_party\OpenDDS\lib\
+           xcopy .\Output\bin32\*.* .\third_party\OpenDDS\ACE_wrappers\bin\
+           xcopy .\Output\x86\*.dll .\third_party\OpenDDS\ACE_wrappers\lib\
 
-      - name: Build OpenDDS x86
-        shell: cmd
-        run: |
-          cd third_party\OpenDDS
-          call setenv.cmd
-          msbuild -p:Configuration=Release,Platform=Win32 -m DDS_TAOv2.sln
-
-      - name: Move OpenDDS x86
-        shell: cmd
-        run: |
-          cd third_party\OpenDDS
-          xcopy .\lib\*.dll ..\..\Output\x86\
-          xcopy .\lib\*.pdb ..\..\Output\pdb32\
-          xcopy .\lib\*.lib ..\..\Output\lib32\
-          xcopy .\bin\*.exe ..\..\Output\bin32\
-          xcopy .\bin\*.pdb ..\..\Output\pdb32\
-          xcopy .\ACE_wrappers\lib\*.dll ..\..\Output\x86\
-          xcopy .\ACE_wrappers\lib\*.pdb ..\..\Output\pdb32\
-          xcopy .\ACE_wrappers\lib\*.lib ..\..\Output\lib32\
-          xcopy .\ACE_wrappers\bin\*.exe ..\..\Output\bin32\
-          xcopy .\ACE_wrappers\bin\*.pdb ..\..\Output\pdb32\
+    #  - name: Build OpenDDS x64
+    #    shell: cmd
+    #    run: |
+    #      cd third_party\OpenDDS
+    #      call setenv.cmd
+    #      msbuild -p:Configuration=Release,Platform=x64 -m DDS_TAOv2.sln
+    #
+    #  - name: Move OpenDDS x64
+    #    shell: cmd
+    #    run: |
+    #      cd third_party\OpenDDS
+    #      xcopy .\lib\*.dll ..\..\Output\x64\
+    #      xcopy .\lib\*.pdb ..\..\Output\pdb64\
+    #      xcopy .\lib\*.lib ..\..\Output\lib64\
+    #      xcopy .\bin\*.exe ..\..\Output\bin64\
+    #      xcopy .\bin\*.pdb ..\..\Output\pdb64\
+    #      xcopy .\ACE_wrappers\lib\*.dll ..\..\Output\x64\
+    #      xcopy .\ACE_wrappers\lib\*.pdb ..\..\Output\pdb64\
+    #      xcopy .\ACE_wrappers\lib\*.lib ..\..\Output\lib64\
+    #      xcopy .\ACE_wrappers\bin\*.exe ..\..\Output\bin64\
+    #      xcopy .\ACE_wrappers\bin\*.pdb ..\..\Output\pdb64\
+    #
+    #  - name: Build OpenDDS x86
+    #    shell: cmd
+    #    run: |
+    #      cd third_party\OpenDDS
+    #      call setenv.cmd
+    #      msbuild -p:Configuration=Release,Platform=Win32 -m DDS_TAOv2.sln
+    #
+    #  - name: Move OpenDDS x86
+    #    shell: cmd
+    #    run: |
+    #      cd third_party\OpenDDS
+    #      xcopy .\lib\*.dll ..\..\Output\x86\
+    #      xcopy .\lib\*.pdb ..\..\Output\pdb32\
+    #      xcopy .\lib\*.lib ..\..\Output\lib32\
+    #      xcopy .\bin\*.exe ..\..\Output\bin32\
+    #      xcopy .\bin\*.pdb ..\..\Output\pdb32\
+    #      xcopy .\ACE_wrappers\lib\*.dll ..\..\Output\x86\
+    #      xcopy .\ACE_wrappers\lib\*.pdb ..\..\Output\pdb32\
+    #      xcopy .\ACE_wrappers\lib\*.lib ..\..\Output\lib32\
+    #      xcopy .\ACE_wrappers\bin\*.exe ..\..\Output\bin32\
+    #      xcopy .\ACE_wrappers\bin\*.pdb ..\..\Output\pdb32\
 
       - name: Generate OpenDDS projects
         shell: cmd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
         id: cache
         with:
           lookup-only: true
+          enableCrossOsArchive: true
           path: ./OutputOpenDDS/
           key: OpenDDS_3.25
           
@@ -145,6 +146,7 @@ jobs:
       - name: Save OpenDDS in cache
         uses: actions/cache/save@v3
         with:
+          enableCrossOsArchive: true
           path: ./OutputOpenDDS/
           key: OpenDDS_3.25
 
@@ -229,6 +231,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           fail-on-cache-miss: true
+          enableCrossOsArchive: true
           path: ./OutputOpenDDS/
           key: OpenDDS_3.25
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The PR updates workflows to use GitHub cache to store OpenDDS artifacts within Pull Requests and Release.
This speedup both actions because of stored information.
If cache is not available it will be rebuilt before execute the action

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closed #42 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested running workflows

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
